### PR TITLE
Set intelligent default user option and remove need for "home_dir" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ This role installs the powerline fonts from the project [https://github.com/powe
 Role Variables
 --------------
 
+No role variables need to set due to reasonable defaults.
+
 ```yaml
 all_users:              # this role can configure for one or more users
-  - user: foo           # username
-    homedir: /home/foo  # the home dir for the username
+  - user: foo           # username. Defaults to current user
 
-all_fonts:              # the fonts you want to install
+all_fonts:              # the fonts you want to install. Defaults shown here.
   - RobotoMono          # the name of these fonts must match the name of the
   - SourceCodePro       # font directory
   - DejaVuSansMono
@@ -31,3 +32,5 @@ Author Information
 ------------------
 
 Tiago M. Vieira - [https://github.com/tvieira](https://github.com/tvieira)
+Cruse, Si - [https://github.com/sicruse](https://github.com/sicruse)
+Mark Stosberg - [https://github.com/markstos](https://github.com/markstos)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 
 all_users:
-  - user: foo
-    homedir: /home/foo
+  - user: "{{ ansible_user_id }}"
 
 # see the list of fonts at https://github.com/powerline/fonts
 # the names must match the directory names for each font

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,8 @@
 
 - name: ensure all users have a local fonts directory
   file:
-    dest: "{{ item.homedir }}/{{ font_directory }}"
+    # First tilde expands to home dir via expanduser. Others tildes are for concatenation.
+    dest: "{{ '~' ~ item.user ~ '/' ~ font_directory | expanduser }}"
     state: directory
     owner: "{{ item.user }}"
     # group: "{{ item.user }}"
@@ -33,7 +34,7 @@
     - powerline-fonts
 
 - name: copy fonts
-  command: cp -r /tmp/powerline-fonts/{{ item[1] }} {{ item[0].homedir }}/{{ font_directory }}
+  command: cp -r /tmp/powerline-fonts/{{ item[1] }} {{ '~' ~ item[0].user ~ '/' ~ font_directory | expanduser }}
   with_nested:
    - "{{ all_users }}"
    - "{{ all_fonts }}"
@@ -42,7 +43,7 @@
 
 - name: set fonts directory ownership
   file:
-    dest: "{{ item[0].homedir }}/{{ font_directory }}/{{ item[1] }}"
+    dest: "{{ '~' ~ item[0].user ~ '/' ~ font_directory ~ '/' ~ item[1] | expanduser }}"
     state: directory
     owner: "{{ item[0].user }}"
     # group: "{{ item[0].user }}"
@@ -54,5 +55,5 @@
     - powerline-fonts
 
 - name: reset font cache
-  command: fc-cache -f {{ item.homedir }}/{{ font_directory }}
+  command: fc-cache -f {{ '~' ~ item.user ~ '/' ~ font_directory | expanduser }}
   with_items: "{{ all_users }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
-- set_fact: font_directory="{{ 'Library/Fonts' if ansible_os_family == "Darwin" | default('.local/share/fonts') }}"
+- set_fact:
+    font_directory: "{{ 'Library/Fonts' if ansible_os_family == 'Darwin' else '.local/share/fonts' }}"
 
 - name: install fontconfig
   become: ansible_os_family == "Debian"


### PR DESCRIPTION
- We now default to the current user, using ansible_user_id variable
 - home_dir is no longer required. Instead, we use the Ansible built-in feature of tilde expansion to calculate it.

  Tested on Ansible 2.7.